### PR TITLE
Add /norestart and /l*v to Qalculate! chocolateyInstall.ps1

### DIFF
--- a/qalculate/tools/chocolateyInstall.ps1
+++ b/qalculate/tools/chocolateyInstall.ps1
@@ -10,7 +10,7 @@ $packageArgs = @{
   checksumType           = 'sha256'
   checksumType64         = 'sha256'
   softwareName           = 'Qalculate!*'
-  silentArgs             = '/qn'
+  silentArgs             = '/qn /norestart /l*v `"$($Env:TEMP)\$($packageName).$($Env:chocolateyPackageVersion).MsiInstall.log`"'
   validExitCodes         = @(0)
 }
 


### PR DESCRIPTION
Standard MSI behavior flags /norestart and /l are added to the silentArgs key of the $packageArgs array to further reinforce a deterministic outcome for the script. These flags and still others are officially documented at:
<https://learn.microsoft.com/en-us/windows/win32/msi/standard-installer-command-line-options>

Without a flag to explicitly set the behavior, when a package installed from the command line using msiexec.exe (as the
Install-ChocolateyPackage commandlet does) requests a system reboot, the default is to grant the request immediately without notifying the user. This is a serious breach of user autonomy with potential data loss implications that the addition of this flag prevents completely.

The '/l*v <filePath>' flag activates verbose logging of all actions taken by the installer in the event adverse behavior is experienced by a user. With scripted behaviors such as the ones regularly performed by Chocolatey, it is imperative that users have some record of what was done "behind the scenes" if a need to troubleshoot arises. This flag ensures such a record exists and places it in an intuitive, accessible location.

Furthermore, these behavior flags are now recommended for all MSI installer packages as part of package creation best practices, as documented at:
<https://docs.chocolatey.org/en-us/guides/create/create-msi-package/#creating-your-install-script>