### PR TITLE
Correct logging behavior introduced in 507a233

### DIFF
--- a/qalculate/qalculate.nuspec
+++ b/qalculate/qalculate.nuspec
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<!--
+  SPDX-FileCopyrightText: © 2018–2020, Emrik Östling <hi@emrik.org>
+
+  SPDX-License-Identifier: MIT
+--><!--
+  Do not remove this test for UTF-8: if “Ω” doesn't appear as Greek uppercase
+  letter omega (Ohm unit symbol) enclosed in curly/"smart" quotation marks, you
+  should use a text editor that supports UTF-8, and not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>qalculate</id>

--- a/qalculate/tools/chocolateyInstall.ps1
+++ b/qalculate/tools/chocolateyInstall.ps1
@@ -1,4 +1,58 @@
-﻿$ErrorActionPreference = 'Stop'
+﻿# SPDX-FileCopyrightText: © 2018–2023, Emrik Östling <hi@emrik.org>
+# SPDX-FileCopyrightText: © 2024–2025, Peter J. Mello <admin@petermello.net>
+#
+# SPDX-License-Identifier: MIT
+
+$ErrorActionPreference = 'Stop'
+
+$chocoPkgInstallLogFile = (Join-Path -Path "${Env:TEMP}" `
+  -ChildPath "${packageName}-${Env:chocolateyPackageVersion}-MsiInstall.log")
+$chocoPkgInstallLogDir = (Split-Path "${chocoPkgInstallLogFile}" -Parent)
+
+function Test-PkgInstallLogDirWritable {
+  [CmdletBinding()]
+  [OutputType([Int])]
+  param([string]${Directory})
+  Try {
+    if ((Test-Path -Path "${Directory}") -and (
+      Test-Path -Path "${Directory}" -PathType Container -Access Write
+    )) {
+      Return 0
+    }
+  }
+  Catch {
+    Return 1
+  }
+}
+
+
+function Set-PkgInstallLogDirWritable {
+  [CmdletBinding(supportsShouldProcess)]
+  [OutputType([Int])]
+  param([string]${Directory})
+  Try {
+    if (-not (Test-Path -Path "${Directory}")) {
+      New-Item -Path "${Directory}" -ItemType Directory
+    }
+    $logDirAcl = Get-Acl -Path "${Directory}"
+    $logDirRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+      "Everyone", "Write", "Allow"
+    )
+    ${logDirAcl}.SetAccessRule(${logDirRule})
+    Set-Acl -Path "${Directory}" -AclObject "${logDirAcl}"
+    Return 0
+  }
+  Catch {
+    Return 1
+  }
+}
+
+if (Test-PkgInstallLogDirWritable -Directory "${chocoPkgInstallLogDir}") {
+  Write-Information "Logging directory exists and is writable; proceeding with installation…"
+} elseif (Set-PkgInstallLogDirWritable -Directory "${chocoPkgInstallLogDir}") {
+  Write-Error "Unable to change logging directory permissions; aborting…"
+  Exit 1
+}
 
 $packageArgs = @{
   packageName            = 'qalculate'
@@ -10,7 +64,7 @@ $packageArgs = @{
   checksumType           = 'sha256'
   checksumType64         = 'sha256'
   softwareName           = 'Qalculate!*'
-  silentArgs             = '/qn /norestart /l*v `"$($Env:TEMP)\$($packageName).$($Env:chocolateyPackageVersion).MsiInstall.log`"'
+  silentArgs             = "/qn /norestart /l*v ${chocoPkgInstallLogFile}"
   validExitCodes         = @(0)
 }
 

--- a/qalculate/tools/chocolateyInstall.ps1
+++ b/qalculate/tools/chocolateyInstall.ps1
@@ -65,8 +65,8 @@ $packageArgs = @{
   checksumType64         = 'sha256'
   softwareName           = 'Qalculate!*'
   silentArgs             = "/qn /norestart /l*v ${chocoPkgInstallLogFile}"
-  validExitCodes         = @(0)
+  validExitCodes         = @(0, 3010)
 }
 
 Install-ChocolateyPackage @packageArgs
-Install-BinFile -Name qalc -Path "C:\Program Files\Qalculate\qalc.exe"
+Install-BinFile -Name qalc -Path "${Env:ProgramFiles}\Qalculate\qalc.exe"

--- a/qalculate/tools/chocolateyUninstall.ps1
+++ b/qalculate/tools/chocolateyUninstall.ps1
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2025, Peter J. Mello <admin@petermello.net>
+#
+# SPDX-License-Identifier: MIT
+
+$ErrorActionPreference = 'Stop'
+
+$packageName = 'qalculate'
+$softwareName = 'qalculate*'
+$installerType = 'MSI'
+$silentArgs = '/qn /norestart'
+$validExitCodes = @(0, 3010, 1605, 1614, 1641)
+
+$local_key     = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
+$machine_key   = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+$machine_key6432 = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+
+$key = Get-ItemProperty -Path @($machine_key6432,$machine_key, $local_key) `
+                        -ErrorAction SilentlyContinue `
+         | Where-Object { $_.DisplayName -like "$softwareName" }
+
+if (${key}.Count -eq 1) {
+  ${key} | ForEach-Object {
+      $silentArgs = "$($_.PSChildName) ${silentArgs}"
+  }
+  Uninstall-ChocolateyPackage -PackageName ${packageName} `
+                              -FileType ${installerType} `
+                              -SilentArgs "${silentArgs}" `
+                              -ValidExitCodes ${validExitCodes}
+  Uninstall-BinFile -Name qalc -Path "C:\Program Files\Qalculate\qalc.exe"
+} elseif (${key}.Count -eq 0) {
+  Write-Warning "${packageName} has already been uninstalled by other means."
+} elseif (${key}.Count -gt 1) {
+  Write-Warning "$key.Count matches found!"
+  Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+  Write-Warning "Please alert package maintainer the following keys were matched:"
+  $key | ForEach-Object { Write-Warning "- $_.DisplayName" }
+}

--- a/qalculate/tools/chocolateyUninstall.ps1
+++ b/qalculate/tools/chocolateyUninstall.ps1
@@ -4,34 +4,37 @@
 
 $ErrorActionPreference = 'Stop'
 
-$packageName = 'qalculate'
-$softwareName = 'qalculate*'
-$installerType = 'MSI'
-$silentArgs = '/qn /norestart'
-$validExitCodes = @(0, 3010, 1605, 1614, 1641)
+$packageArgs = @{
+  PackageName    = 'qalculate'
+  FileType       = 'MSI'
+  SilentArgs     = '/qn /norestart'
+  ValidExitCodes = @(0, 3010, 1605, 1614, 1641)
+}
 
-$local_key     = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
-$machine_key   = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+$softwareName    = 'Qalculate!*'
+$local_key       = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
+$machine_key     = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
 $machine_key6432 = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
 
-$key = Get-ItemProperty -Path @($machine_key6432,$machine_key, $local_key) `
-                        -ErrorAction SilentlyContinue `
-         | Where-Object { $_.DisplayName -like "$softwareName" }
+$key = Get-ItemProperty -Path @(
+  ${machine_key6432}, ${machine_key}, ${local_key}
+  ) -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -like "${softwareName}"
+  }
 
 if (${key}.Count -eq 1) {
   ${key} | ForEach-Object {
-      $silentArgs = "$($_.PSChildName) ${silentArgs}"
+    $silentArgs = "$($_.PSChildName) ${silentArgs}"
   }
-  Uninstall-ChocolateyPackage -PackageName ${packageName} `
-                              -FileType ${installerType} `
-                              -SilentArgs "${silentArgs}" `
-                              -ValidExitCodes ${validExitCodes}
-  Uninstall-BinFile -Name qalc -Path "C:\Program Files\Qalculate\qalc.exe"
+  Uninstall-ChocolateyPackage @packageArgs
+  Uninstall-BinFile -Name qalc -Path "${Env:ProgramFiles}\Qalculate\qalc.exe"
 } elseif (${key}.Count -eq 0) {
   Write-Warning "${packageName} has already been uninstalled by other means."
 } elseif (${key}.Count -gt 1) {
-  Write-Warning "$key.Count matches found!"
+  Write-Warning "${key}.Count matches found!"
   Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
   Write-Warning "Please alert package maintainer the following keys were matched:"
-  $key | ForEach-Object { Write-Warning "- $_.DisplayName" }
+  ${key} | ForEach-Object {
+    Write-Warning "- $_.DisplayName"
+  }
 }

--- a/qalculate/update.ps1
+++ b/qalculate/update.ps1
@@ -1,4 +1,8 @@
-import-module au
+# SPDX-FileCopyrightText: © 2018–2021, Emrik Östling <hi@emrik.org>
+# SPDX-FileCopyrightText: © 2025, Peter J. Mello <admin@petermello.net>
+#
+# SPDX-License-Identifier: MIT
+Import-Module -Name AU
 
 $releases = 'https://github.com/Qalculate/qalculate-gtk/releases'
 
@@ -21,9 +25,11 @@ function global:au_BeforeUpdate() {
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-    $url64  = $download_page.links | ? href -match '.msi$' | % href | select -First 1
+    $url64  = $download_page.links | Where-Object href -match '.msi$' |
+                  ForEach-Object href | Select-Object -First 1
     $url32   = $url64 -replace '-x64.msi$', '-i386.msi'
-	$version = ($url64 -split '/' | select -last 1)  -split '-' | select -first 1 -skip 1
+	$version = ($url64 -split '/' | Select-Object -last 1)  -split '-' |
+                  Select-Object -first 1 -skip 1
 
     @{
         URL32   = $url32
@@ -32,4 +38,4 @@ function global:au_GetLatest {
     }
 }
 
-update -ChecksumFor all
+Update-Package -ChecksumFor all


### PR DESCRIPTION
Well it looks like the Chocolatey documentation leaves even more to be desired than appears at first glance…their own recommended value for SilentArgs crashes and burns. 😮‍💨 I'll be honest, my earlier pull request didn't involve much testing, as it seemed logical to assume that the documentation would keep things on the right path. This PR is a bit hasty since I felt bad about busting up the status quo and didn't want to leave you holding the bag, but I've given it enough time in the forge to feel satisfied that it's without question a step in the right direction, and likely the end solution. Feel free to inquire further, but a brief summary of the changes is:
- Add functions to chocolateyInstall.ps1 to test the logging path and its ACL for writable status and try to correct them at runtime if insufficient.
- Create a tools/chocolateyUninstall.ps1 script to explicitly handle package removal, including the removal of the qalc.exe CLI moved upon install.
- Add SPDX licensing and copyright tags to all relevant files, just for the sake of being thorough.
- Run all PowerShell scripts through PSScriptAnalyzer linter and resolve all errors and warnings.

Hope everything is well with you as we get underway in the new year, and that this squashes these bugs swiftly and convincingly.

Warmly,
Peter (RogueScholar) Mello